### PR TITLE
Add non-existent username scenario to balance

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -117,14 +117,17 @@ def balance(bot, update, args):
         update.message.reply_text('username is required.')
     else:
         username = str(args[0])
-        if len(args) > 1:
-            bals = get_balance(username, in_commodity=str(args[1]))
-        else:
-            bals = get_balance(username)
-        bals = (bals[:500] + '..') if len(bals) > 500 else bals
-        if bals == '' or len(bals) == 0:
-            bals = '0'
-        update.message.reply_text(bals)
+        # if username exists:
+            if len(args) > 1:
+                bals = get_balance(username, in_commodity=str(args[1]))
+            else:
+                bals = get_balance(username)
+            bals = (bals[:500] + '..') if len(bals) > 500 else bals
+            if bals == '' or len(bals) == 0:
+                bals = '0'
+            update.message.reply_text(bals)
+        # else:
+            update.message.reply_text("Username does not exist or I'm on my break.")
     return
 
 


### PR DESCRIPTION
I've provided comments on the idea. I don't expect this to get merged like this. Hope we can work it out.

Username from line 119 and in other bot functions needs to get checked for membership/existence prior to giving out balance  or executing other functions. If username is not found, bot would need to submit reply message indicating so, instead of returning a balance of 0. 

Not sure what the output is for non-existing members regarding balance if username is not found. 

Checking the guldlib, I'm wondering what is the output for `subprocess.check_output(cmd, shell=True)` and what does it return with `return ledgerBals.decode("utf-8")` if its `username` isn't found in the users `BLOCKTREE ` directory? 

Look at these lines from guldlib ([here](https://github.com/guldcoin/python-guldlib/blob/74ecddf4d5b655ace2c62ab53f5a4ed7b319f39e/guldlib.py#L74-L81)):

![image](https://user-images.githubusercontent.com/22228397/37498355-e2a2706c-288b-11e8-95a7-019c3d8daafb.png)

The output of `return ledgerBals.decode("utf-8")` mentioned above gets stored in guld-ai-telegram with `bals = get_balance(username)` ([here](https://github.com/guldcoin/guld-ai-telegram/blob/c8b62313f448ab494fb2ae28b7c95a5812e9a129/bot.py#L115-L128)), as shown below:

![image](https://user-images.githubusercontent.com/22228397/37498170-c275bb1a-288a-11e8-863f-2560b7454aac.png)

Due to the above ` if bals == '' or len(bals) == 0:` I'm assuming that `bals` can return an empty string. Does an empty string means username does not exist? The execution of this conditional still returns `bals = '0'`  with `update.message.reply_text(bals)`. If empty string means username does not exist, then perhaps solution would be to modify code here to contemplate scenario wherein `username` isn't found in the `BLOCKTREE` user directory. 

Please do note that same solution can be applied when non-existing `username` tries to send funds to another user, either existing or non-existing.